### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/uv.yml
+++ b/.github/workflows/uv.yml
@@ -1,4 +1,6 @@
 name: UV CI
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/rahulsom/pallanguzhi/security/code-scanning/1](https://github.com/rahulsom/pallanguzhi/security/code-scanning/1)

The best practice is to add a `permissions` block to the workflow with the minimum required permissions. By default, `permissions: {}` denies all, but to allow deployment to `gh-pages` using `peaceiris/actions-gh-pages`, the GITHUB_TOKEN used by that step needs `contents: write` (for pushing to the repository). All other steps likely do not require elevated permissions, so the safest minimal permissions block should be set at the top-level (workflow), unless some jobs have different needs.

**How to fix:**  
Add a `permissions` key after the workflow `name` and before the `on:` block, specifying `contents: write` (since static site deployment requires push access). This will apply to all jobs in the workflow. If stricter separation of permissions is desired for different jobs, the `permissions` key can be set per-job, but in this single-job workflow, top-level is cleaner and clearer.

**What is needed:**  
Insert (after `name: UV CI`) the following block:

```yaml
permissions:
  contents: write
```

No other code, method, or import changes are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
