### PR TITLE
chore: Use dependency-groups for uv dev-dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@ dependencies = [
     "torch==2.8.0",
 ]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "ruff==0.13.3",
     "pytest==8.4.2",
 ]


### PR DESCRIPTION
The `tool.uv.dev-dependencies` field is deprecated in `uv`.
This change migrates the development dependencies to the new `[tool.dependency-groups.dev]` table in `pyproject.toml` to resolve the deprecation warning and align with modern `uv` configuration.
